### PR TITLE
Fix failed to commit and rollback the connection while throw sql exception

### DIFF
--- a/samples/userstores/jdbc-sample-userstore/components/org.wso2.carbon.identity.user.store.jdbc.sample/src/main/java/org/wso2/carbon/identity/user/store/jdbc/sample/CloudSampleJDBCUserStoreManager.java
+++ b/samples/userstores/jdbc-sample-userstore/components/org.wso2.carbon.identity.user.store.jdbc.sample/src/main/java/org/wso2/carbon/identity/user/store/jdbc/sample/CloudSampleJDBCUserStoreManager.java
@@ -209,7 +209,15 @@ public class CloudSampleJDBCUserStoreManager extends JDBCUserStoreManager {
             if (rs.next() == true) {
                 isExist = true;
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to rollback the transaction", e);
+                }
+            }
             String msg = "Error occurred while retrieving user info for user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(msg, e);
@@ -266,7 +274,15 @@ public class CloudSampleJDBCUserStoreManager extends JDBCUserStoreManager {
             if (rs.next()) {
                 isAuthed = true;
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to rollback the transaction", e);
+                }
+            }
             String msg = "Error occurred while retrieving user authentication info for user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(msg, e);

--- a/samples/userstores/jdbc-sample-userstore/components/org.wso2.carbon.identity.user.store.jdbc.sample/src/main/java/org/wso2/carbon/identity/user/store/jdbc/sample/CloudSampleJDBCUserStoreManager.java
+++ b/samples/userstores/jdbc-sample-userstore/components/org.wso2.carbon.identity.user.store.jdbc.sample/src/main/java/org/wso2/carbon/identity/user/store/jdbc/sample/CloudSampleJDBCUserStoreManager.java
@@ -102,15 +102,7 @@ public class CloudSampleJDBCUserStoreManager extends JDBCUserStoreManager {
             this.updateStringValuesToDatabase(dbConnection, sqlStmt1, userName, password, tenantId);
             dbConnection.commit();
         } catch (Exception e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                String errorMessage = "Error while rollback in add user operation for user : " + userName;
-                if (log.isDebugEnabled()) {
-                    log.debug(errorMessage, e1);
-                }
-                throw new UserStoreException(errorMessage, e1);
-            }
+            rollBackTransaction(dbConnection);
             String errorMessage = "Error while persisting user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
@@ -211,13 +203,7 @@ public class CloudSampleJDBCUserStoreManager extends JDBCUserStoreManager {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Failed to rollback the transaction", e);
-                }
-            }
+            rollBackTransaction(dbConnection);
             String msg = "Error occurred while retrieving user info for user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(msg, e);
@@ -276,13 +262,7 @@ public class CloudSampleJDBCUserStoreManager extends JDBCUserStoreManager {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Failed to rollback the transaction", e);
-                }
-            }
+            rollBackTransaction(dbConnection);
             String msg = "Error occurred while retrieving user authentication info for user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(msg, e);
@@ -451,15 +431,7 @@ public class CloudSampleJDBCUserStoreManager extends JDBCUserStoreManager {
             this.updateStringValuesToDatabase(dbConnection, sqlStmt, userName, tenantId);
             dbConnection.commit();
         } catch (Exception e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                String errorMessage = "Error while rollback in delete user operation for user : " + userName;
-                if (log.isDebugEnabled()) {
-                    log.debug(errorMessage, e1);
-                }
-                throw new UserStoreException(errorMessage, e1);
-            }
+            rollBackTransaction(dbConnection);
             String errorMessage = "Error while deleting user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
@@ -468,6 +440,20 @@ public class CloudSampleJDBCUserStoreManager extends JDBCUserStoreManager {
         } finally {
             DatabaseUtil.closeAllConnections(dbConnection);
         }
+    }
 
+    /**
+     * Revoke the transaction when catch then sql transaction errors.
+     *
+     * @param dbConnection database connection.
+     */
+    private void rollBackTransaction(Connection dbConnection) {
+        try {
+            if (dbConnection != null) {
+                dbConnection.rollback();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while rolling back transactions. ", e1);
+        }
     }
 }


### PR DESCRIPTION


### Proposed changes in this pull request

When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the identity-cloud repository, there are some places use the JDBC transaction but did not properly rollback the transaction.

Issue: https://github.com/wso2/product-is/issues/5435